### PR TITLE
String pluralization

### DIFF
--- a/README.md
+++ b/README.md
@@ -104,9 +104,9 @@ You could plularization your Strings. Use **%b{true:false}** notion, where left 
 ```
 ```dart
 final count = 2;
-String text = 'person-text',
+String text = 'person-text'.i18n(
         [], //args is a required positional parameter, if you don't gave a %s notation pass empty list []
-        conditions: [count > 1],;
+        conditions: [count > 1]);
 print(text); // Welcome, person
 ```
 **

--- a/README.md
+++ b/README.md
@@ -107,7 +107,7 @@ final count = 2;
 String text = 'person-text'.i18n(
         [], //args is a required positional parameter, if you don't gave a %s notation pass empty list []
         conditions: [count > 1]);
-print(text); // Welcome, person
+print(text); // Welcome, people
 ```
 **
 **THAT`S IT!

--- a/README.md
+++ b/README.md
@@ -96,7 +96,21 @@ print(text); // Welcome, Peter
 ```
 The **%s** notation can also be retrieved positionally. Just use **%s0, %s1, %s2**...
 
-THAT`S IT!
+You could plularization your Strings. Use **%b{true:false}** notion, where left is a string value when condition is true and on the right is a value when condition is false:
+```json
+{
+  "person-text": "Welcome, %b{people:person}"
+}
+```
+```dart
+final count = 2;
+String text = 'person-text',
+        [], //args is a required positional parameter, if you don't gave a %s notation pass empty list []
+        conditions: [count > 1],;
+print(text); // Welcome, people
+```
+**
+**THAT`S IT!
 
 ## Additional settings
 

--- a/README.md
+++ b/README.md
@@ -105,7 +105,7 @@ You could plularization your Strings. Use **%b{true:false}** notion, where left 
 ```dart
 final count = 2;
 String text = 'person-text'.i18n(
-        [], //args is a required positional parameter, if you don't gave a %s notation pass empty list []
+        [], //args is a required positional parameter, if you don't gave a %s notation give a empty list []
         conditions: [count > 1]);
 print(text); // Welcome, people
 ```

--- a/README.md
+++ b/README.md
@@ -107,7 +107,7 @@ final count = 2;
 String text = 'person-text',
         [], //args is a required positional parameter, if you don't gave a %s notation pass empty list []
         conditions: [count > 1],;
-print(text); // Welcome, people
+print(text); // Welcome, person
 ```
 **
 **THAT`S IT!

--- a/lib/src/localization_extension.dart
+++ b/lib/src/localization_extension.dart
@@ -1,7 +1,11 @@
 import 'localization_service.dart';
 
 extension LocalizationExtension on String {
-  String i18n([List<String> arguments = const []]) {
-    return LocalizationService.instance.read(this, arguments);
+  String i18n([List<String> arguments = const [], List<bool>? conditions]) {
+    return LocalizationService.instance.read(
+      this,
+      arguments,
+      conditions: conditions,
+    );
   }
 }

--- a/test/src/localization_service_test.dart
+++ b/test/src/localization_service_test.dart
@@ -48,6 +48,29 @@ void main() {
       var value = LocalizationService.instance.read('full-name-complete-positional', ['Araujo', 'Moura']);
       expect(value, 'Jacob Araujo Moura %s9');
     });
+
+    test('Read with false condition arguments', () {
+      var count = 1;
+      LocalizationService.instance.addSentence('person-label', '%s %b{people:person}');
+
+      var value = LocalizationService.instance.read(
+        'person-label',
+        [count.toString()],
+        conditions: [count > 1],
+      );
+      expect(value, '1 person');
+    });
+    test('Read with true condition arguments', () {
+      final count = 2;
+      LocalizationService.instance.addSentence('person-label', '%s %b{people:person}');
+
+      var value = LocalizationService.instance.read(
+        'person-label',
+        [count.toString()],
+        conditions: [count > 1],
+      );
+      expect(value, '2 people');
+    });
   });
 
   group('json file', () {


### PR DESCRIPTION
A feature de pluralização de String foi removida da versão 2 do pacote do localization com o argumento que a esta regra não deveria ser responsabilidade do package e sim do desenvolvimento do aplicativo.
Entretanto foi notado que existem packages de localização de sucesso que possuem essa feature, inclusive o package oficial do Flutter, o intl
https://pub.dev/packages/intl
Ele utiliza uma forma um pouco complexa
![image](https://user-images.githubusercontent.com/2637049/153866728-17542cec-65e8-4d2f-91fa-c9257a7f29e8.png)
Recebi feedbacks que nossa forma com o %b era uma forma bem mais simples, então este PR é a reimplementação do %b
