### PR TITLE
update the version of `fluent_ui` and `flutter_modular`

### DIFF
--- a/localization_ui/pubspec.yaml
+++ b/localization_ui/pubspec.yaml
@@ -36,9 +36,9 @@ dependencies:
   lazy_data_table_plus: ^1.0.0
   lazy_data_table: ^0.3.1
   bitsdojo_window: ^0.1.1+1
-  fluent_ui: ^3.9.0
+  fluent_ui: ^3.12.0
   system_theme: ^1.0.1
-  flutter_modular: ^4.5.0
+  flutter_modular: ^5.0.3
   desktop_window: ^0.4.0
   window_size:
     git:


### PR DESCRIPTION
to avoid these types of errors below blocking launch:

- `flutter error: type 'xxx' not found.` 

- `flutter context: 'xxx' is defined here.` 

such as `widget_module.dart:38:8: Error: Type 'SingletonBind' not found.`